### PR TITLE
Clean up template, don't use -common

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
       src="https://www.w3.org/Tools/respec/respec-w3c"
     ></script>
     <script class="remove">
-			// See: https://respec.org/docs/ for all configuration options
+      // See: https://respec.org/docs/ for all configuration options
       var respecConfig = {
         shortName: "my-note",
         specStatus: "ED", // "WG-NOTE"
@@ -20,8 +20,8 @@
             name: "Victor Hugo",
             w3cid: "0000",
           },
-				],
-				group: "webperfs", // find your group at https://respec.org/w3c/groups/
+        ],
+        group: "webperfs", // find your group at https://respec.org/w3c/groups/
         github: {
           repoURL: "w3c/mynote",
           branch: "master",

--- a/index.html
+++ b/index.html
@@ -1,44 +1,47 @@
 <!DOCTYPE html>
 <html>
-<head>
-	<meta content="text/html; charset=utf-8" http-equiv="content-type">
-	<title>MyNote</title>
-	<script async class="remove" src=
-	"https://www.w3.org/Tools/respec/respec-w3c-common">
-	</script>
-	<script class="remove">
-	 var respecConfig = {
-     shortName:            "timing-entrytypes-registry",
-	   specStatus:           "ED",
-     // specStatus:           "WG-NOTE",
-     noRecTrack: true,
-     edDraftURI:  "https://w3c.github.io/mynote/",
-     editors:  [
-      {
-        name:    "Victor Hugo"
-	      ,  w3cid:   "0000"
-	     }
-	     ],
-	     wg: "MyNote Working Group",
-	     wgURI: "https://www.w3.org/wg/mynote/",
-	     wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/53154/status",
-	     github: {
-				 repoURL: "https://github.com/w3c/mynote/",
-				 branch: "master"
-			 },
-	   };
-	</script>
-</head>
-<body>
-	<section id="abstract">
-		<p>This is a Note.</p>
-	</section>
-	<section id="sotd">
-		<p>This is a placeholder document.</p>
-	</section>
-	<section id='purpose'>
-		<h2>Purpose</h2>
-		<p>This is a placeholder. Check the <a href='https://github.com/w3c/respec/wiki'>ReSpec documentation</a>.</p>
-	</section>
-</body>
+  <head>
+    <meta charset="utf-8">
+    <title>MyNote</title>
+    <script
+      defer
+      class="remove"
+      src="https://www.w3.org/Tools/respec/respec-w3c"
+    ></script>
+    <script class="remove">
+			// See: https://respec.org/docs/ for all configuration options
+      var respecConfig = {
+        shortName: "my-note",
+        specStatus: "ED", // "WG-NOTE"
+        noRecTrack: true,
+        edDraftURI: "https://w3c.github.io/mynote/",
+        editors: [
+          {
+            name: "Victor Hugo",
+            w3cid: "0000",
+          },
+				],
+				group: "webperfs", // find your group at https://respec.org/w3c/groups/
+        github: {
+          repoURL: "w3c/mynote",
+          branch: "master",
+        },
+      };
+    </script>
+  </head>
+  <body>
+    <section id="abstract">
+      <p>This is a Note.</p>
+    </section>
+    <section id="sotd">
+      <p>This is a placeholder document.</p>
+    </section>
+    <section id="purpose">
+      <h2>Purpose</h2>
+      <p>
+        This is a placeholder. Check the
+        <a href="https://respec.org/docs/">ReSpec documentation</a>.
+      </p>
+    </section>
+  </body>
 </html>


### PR DESCRIPTION
We are deprecating -common + updated a few other things.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/marcoscaceres/note-respec-repo-template/pull/1.html" title="Last updated on Sep 15, 2020, 5:41 AM UTC (71b4bc7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/note-respec-repo-template/1/6ddf29c...marcoscaceres:71b4bc7.html" title="Last updated on Sep 15, 2020, 5:41 AM UTC (71b4bc7)">Diff</a>